### PR TITLE
[codex] Restrict backend CORS origins to localhost

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -72,7 +72,7 @@ app = FastAPI(title="Ca2+ cell-fie", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["http://localhost:8001", "http://127.0.0.1:8001"],
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## What changed
Restricted the FastAPI CORS configuration in `backend/main.py` from `allow_origins=["*"]` to explicit localhost frontend origins:
- `http://localhost:8001`
- `http://127.0.0.1:8001`

## Why
The previous wildcard origin setting was overly permissive and matched the security issue report about potential CSRF exposure if the app is reachable beyond localhost.

## Validation
- `python3 -m py_compile backend/main.py`
- Imported the FastAPI app from `backend/venv`
- Confirmed the middleware now exposes only the two localhost origins